### PR TITLE
Autorotate script

### DIFF
--- a/99_restart_autorotate
+++ b/99_restart_autorotate
@@ -8,7 +8,7 @@ case $1/$2 in
   post/*)
     echo "Waking up from $2..."
         DISPLAY=:0.0 ; export DISPLAY
-        su $user -c "sleep 5; autorotate.sh &"
+        su $USER -c "sleep 5; autorotate.sh &"
     ;;
 esac
 

--- a/99_restart_autorotate
+++ b/99_restart_autorotate
@@ -2,13 +2,13 @@
 case $1/$2 in
   pre/*)
     echo "Going to $2..."
-    su alberto -c "killall autorotate.sh"
+    su $USER -c "killall autorotate.sh"
     exit 0
     ;;
   post/*)
     echo "Waking up from $2..."
         DISPLAY=:0.0 ; export DISPLAY
-        su alberto -c "sleep 5; autorotate.sh &"
+        su $user -c "sleep 5; autorotate.sh &"
     ;;
 esac
 

--- a/99_restart_autorotate
+++ b/99_restart_autorotate
@@ -1,0 +1,14 @@
+#!/bin/sh
+case $1/$2 in
+  pre/*)
+    echo "Going to $2..."
+    su alberto -c "killall autorotate.sh"
+    exit 0
+    ;;
+  post/*)
+    echo "Waking up from $2..."
+        DISPLAY=:0.0 ; export DISPLAY
+        su alberto -c "sleep 5; autorotate.sh &"
+    ;;
+esac
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # screenrotation
 ubuntu unity indicator to rotate the screen for convertibles (like lenovo yoga)
 
+NOTE: autorotate should work only on Ubuntu 16.04
+
 installation:
 
 1. download file from github and unzip
@@ -11,15 +13,17 @@ installation:
 3. copy screenrotation.svg to /usr/share/pixmaps/                                                              
 ~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/
 
-4. copy screenrotation.sh and screenrotation-indicator.py to /usr/local/bin/                                       
+4. copy autorotate.sh, screenrotation.sh and screenrotation-indicator.py to /usr/local/bin/                                       
+~$ sudo cp ./autorotate.sh /usr/local/bin                                                                    
 ~$ sudo cp ./screenrotation.sh /usr/local/bin                                                                    
 ~$ sudo cp ./screenrotation-indicator.py /usr/local/bin
 
-5. make both files executable                                                                                     
+5. make all files executable                                                                                     
+~$ sudo chmod +x /usr/local/bin/autorotate.sh
 ~$ sudo chmod +x /usr/local/bin/screenrotation-indicator.py                                              
 ~$ sudo chmod +x /usr/local/bin/screenrotation.sh
 
-6. add screenrotation-indicator.py as startup program                                                          
+6. add screenrotation-indicator.py, autorotate.sh as startup programs                                                          
 
 7. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key]                                   
    for lenovo yoga 3 11 you can take Super+O. thats the extra button on the right-hand side, originaly intended 
@@ -32,4 +36,8 @@ http://hangg.com/2015/09/ubuntu-screen-rotation-indicator-fuer-lenovo-yoga-3-11/
 based on:                                                                                                          
 http://askubuntu.com/questions/405628/touchscreen-input-doesnt-rotate-lenovo-yoga-13-yoga-2-pro
 https://gist.github.com/rubo77/daa262e0229f6e398766
+
+Autorotate part based on:
+http://pastebin.com/742KTaS6
+
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ installation:
 3. copy screenrotation.svg to /usr/share/pixmaps/                                                              
 ~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/
 
-4. copy autorotate.sh, screenrotation.sh and screenrotation-indicator.py to /usr/local/bin/                                       
-~$ sudo cp ./autorotate.sh /usr/local/bin                                                                    
-~$ sudo cp ./screenrotation.sh /usr/local/bin                                                                    
+4. copy executables to the right directories (please note that first you have to change $USER to your actual user name in 99_restart_autorotate 
+~$ sudo cp ./autorotate.sh /usr/local/bin
+~$ sudo cp ./screenrotation.sh /usr/local/bin
 ~$ sudo cp ./screenrotation-indicator.py /usr/local/bin
+~$ sudo cp ./99_restart_autorotate /lib/systemd/system-sleep/
 
 5. make all files executable                                                                                     
 ~$ sudo chmod +x /usr/local/bin/autorotate.sh
 ~$ sudo chmod +x /usr/local/bin/screenrotation-indicator.py                                              
 ~$ sudo chmod +x /usr/local/bin/screenrotation.sh
+~$ sudo chmod a+x /lib/systemd/system-sleep/99_restart_autorotate
 
 6. add screenrotation-indicator.py, autorotate.sh as startup programs                                                          
 

--- a/autorotate.sh
+++ b/autorotate.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#(C) Alberto Pianon, April 2016
+# licensed under MIT license
+#
+# based on: http://pastebin.com/742KTaS6
+#
+# Works for Lenovo Yoga 3 11, Ubuntu 16.04 (tested on 64bit version)
+# (does not work for Ubuntu previous versions)
+#
+# IMPORTANT: this script should never be killed and restarted,
+# otherwise for some reason the kernel module may hang
+
+echo "Autorotate" > $HOME/.screen_orientation
+
+xpath=`find /sys/devices/pci0000:00 | grep in_accel_x_raw`
+ypath=`find /sys/devices/pci0000:00 | grep in_accel_y_raw`
+
+if [[ -z $xpath ]]; then
+  zenity --error --text="ERROR: accelerometer not detected by linux kernel"
+  exit 1
+fi
+
+
+current_case=0
+counter=0
+num_iterations=2
+max_iterations=4
+ 
+function increaseCounter
+{
+    c=$1
+    if [[ $c -eq $current_case ]]; then
+        counter=$((counter + 1))
+    else
+        current_case=$c
+        counter=1
+    fi
+}
+ 
+sleep 1
+ 
+while true; do
+ 
+  HDMIConn=`xrandr --query | grep "HDMI1 connected"`
+  if [[ $HDMIConn ]]; then
+      #echo -en "\rHDMI connected, no rotation";
+      HDMIConn=""
+      continue
+  fi 
+  
+  response_time=`/usr/bin/time -f "%e" cat "$xpath" 2>&1 | sed -n 2p`
+
+  if (( `echo "$response_time > 1" | bc -l` )); then
+    zenity --error --text="ERROR: accelerometer kernel module hanging, please restart computer"
+    exit 1
+  fi
+
+  x=`cat "$xpath"`
+  y=`cat "$ypath"`
+
+
+  o=`cat $HOME/.screen_orientation`
+
+
+    if [[ ($x -gt 65400 && $y -gt 50000 && $o == "Autorotate") || $o == "Laptop-Mode" ]]; then
+        increaseCounter 0
+        if [[ $counter -gt $num_iterations && $counter -lt $max_iterations ]]; then
+        screenrotation.sh -l
+        fi
+    fi
+    
+    if [[ ($x -lt 1100 && $x -gt 500 && ($y -lt 701 || $y -gt 5000) && $o == "Autorotate") || $o == "Tablet-Left-Mode" ]]; then
+        increaseCounter 3
+        if [[ $counter -gt $num_iterations && $counter -lt $max_iterations ]]; then
+        screenrotation.sh -tl
+        fi
+    fi
+
+    if [[ (($x -gt 50000  || $x -lt 1100) && $y -gt 700 && $y -lt 1100 && $o == "Autorotate") || $o == "Stand-Mode" ]]; then
+        increaseCounter 2
+        if [[ $counter -gt $num_iterations && $counter -lt $max_iterations ]]; then
+        screenrotation.sh -s
+        fi
+    fi
+
+    if [[ ($x -gt 50000 && $x -lt 65401 && $y -lt 300 && $o == "Autorotate") || $o == "Tablet-Right-Mode"  ]]; then
+        increaseCounter 1
+        if [[ $counter -gt $num_iterations && $counter -lt $max_iterations ]]; then
+          screenrotation.sh -tr
+        fi
+    fi
+    
+    if [[ $o == "Tablet-Mode" ]]; then
+        increaseCounter 4
+        if [[ $counter -gt $num_iterations && $counter -lt $max_iterations ]]; then
+          screenrotation.sh -t
+        fi
+    fi
+  
+  sleep 0.05
+
+done

--- a/autorotate.sh
+++ b/autorotate.sh
@@ -8,6 +8,7 @@
 # (does not work for Ubuntu previous versions)
 #
 # IMPORTANT: this script should never be killed and restarted,
+# (unles when suspending and resuming)
 # otherwise for some reason the kernel module may hang
 
 echo "Autorotate" > $HOME/.screen_orientation

--- a/screenrotation-indicator.py
+++ b/screenrotation-indicator.py
@@ -8,6 +8,10 @@ from gi.repository import Notify as notify
 
 APPINDICATOR_ID = 'screenrotationindicator'
 
+menu_items = {}
+
+os.system('echo "Autorotate" > $HOME/.screen_orientation')
+
 def main():
     indicator = appindicator.Indicator.new(APPINDICATOR_ID, '/usr/share/pixmaps/screenrotation.svg', appindicator.IndicatorCategory.SYSTEM_SERVICES)
     indicator.set_status(appindicator.IndicatorStatus.ACTIVE)
@@ -16,61 +20,37 @@ def main():
     gtk.main()
 
 def build_menu():
-	menu = gtk.Menu()	
-	#laptop-mode
-	item_laptop_mode = gtk.MenuItem('Laptop-Mode')
-	item_laptop_mode.connect('activate', laptopmode)
-	menu.append(item_laptop_mode)
-	#stand-mode
-	item_stand_mode = gtk.MenuItem('Stand-Mode')
-	item_stand_mode.connect('activate', standmode)
-	menu.append(item_stand_mode)
-	#tablet-mode
-	item_tablet_mode = gtk.MenuItem('Tablet-Mode')
-	item_tablet_mode.connect('activate', tabletmode)
-	menu.append(item_tablet_mode)
-	#tablet-left-mode
-	item_tablet_left_mode = gtk.MenuItem('Tablet-Left-Mode')
-	item_tablet_left_mode.connect('activate', tabletleftmode)
-	menu.append(item_tablet_left_mode)
-	#tablet-right-mode
-	item_tablet_right_mode = gtk.MenuItem('Tablet-Right-Mode')
-	item_tablet_right_mode.connect('activate', tabletrightmode)
-	menu.append(item_tablet_right_mode)
-	# quit
-	item_quit = gtk.MenuItem('Quit')
-	item_quit.connect('activate', quit)
-	menu.append(item_quit)
-	menu.show_all()
-	return menu
+   global menu_items
+   menu = gtk.Menu()
+   group = []
+   menu_arr = [
+      'Autorotate', 'Laptop-Mode', 'Stand-Mode', 
+      'Tablet-Mode', 'Tablet-Left-Mode', 'Tablet-Right-Mode'
+   ]
+   for i in range(len(menu_arr)):
+      menu_item = gtk.RadioMenuItem.new_with_label(group, menu_arr[i])
+      group = menu_item.get_group()
+      menu_items[menu_arr[i]] = menu_item      
+      menu.append(menu_item)
+      menu_item.connect("activate", on_menu_select, menu_arr[i])
+   
+   # quit
+   item_quit = gtk.MenuItem('Quit')
+   item_quit.connect('activate', quit)
+   menu.append(item_quit)
+   menu.show_all()
+   return menu
 
-# laptopmode funktion
-def laptopmode(_):
-    notify.Notification.new("Laptop-Mode", None).show()
-    os.system('screenrotation.sh -l')
 
-# standmode funktion
-def standmode(_):
-    notify.Notification.new("Stand-Mode", None).show()
-    os.system('screenrotation.sh -s')    
+def on_menu_select(obj, label):
+   global menu_items
+   if menu_items[label].get_active():
+      notify.Notification.new(label, None).show()
+      os.system('echo "'+label+'" > $HOME/.screen_orientation')
 
-# ltabletmode funktion
-def tabletmode(_):
-    notify.Notification.new("Tablet-Mode", None).show()
-    os.system('screenrotation.sh -t')
-
-# tabletleftmode funktion
-def tabletleftmode(_):
-    notify.Notification.new("Tablet-Left-Mode", None).show()
-    os.system('screenrotation.sh -tl')
-
-# tabletrightmode funktion
-def tabletrightmode(_):
-    notify.Notification.new("Tablet-Right-Mode", None).show()
-    os.system('screenrotation.sh -tr')
-
-# quit funktion
+# quit function
 def quit(_):
+	os.system('echo "laptop" > $HOME/.screen_orientation')
 	notify.uninit() 
 	gtk.main_quit()
 

--- a/screenrotation.sh
+++ b/screenrotation.sh
@@ -116,7 +116,7 @@ else
   echo "laptop-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
-  xinput enable "$TouchpadDevice"
+  synclient TouchpadOff=0
   if [[ -n $isOnboardRunning ]]; then
      killall onboard
   fi

--- a/screenrotation.sh
+++ b/screenrotation.sh
@@ -7,7 +7,6 @@
 #### configuration
 # find your Touchscreen and Touchpad device with the command `xinput`
 TouchscreenDevice='ELAN Touchscreen'
-TouchpadDevice='SYNA2B23:00 06CB:2714'
 
 if [ "$1" = "--help"  ] || [ "$1" = "-h"  ] ; then
 echo 'Usage: screenrotation.sh [OPTION]'
@@ -26,7 +25,6 @@ echo ' -key tablet-left-mode (set keyboard shortcut): screen 90° left, touchpad
 exit 0
 fi
 
-touchpadEnabled=$(xinput --list-props "$TouchpadDevice" | awk '/Device Enabled/{print $NF}')
 screenMatrix=$(xinput --list-props "$TouchscreenDevice" | awk '/Coordinate Transformation Matrix/{print $5$6$7$8$9$10$11$12$NF}')
 
 # Matrix for rotation
@@ -58,53 +56,68 @@ left_float='0.000000,-1.000000,1.000000,1.000000,0.000000,0.000000,0.000000,0.00
 #⎣  0 0 1 ⎦
 right='0 1 0 -1 0 1 0 0 1'
 
+isOnboardRunning=`ps -A | grep onboard`
 
 if [ "$1" == "-l" ]
 then
   echo "laptop-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
-  xinput enable "$TouchpadDevice"
-  killall onboard
+  synclient TouchpadOff=0
+  if [[ -n $isOnboardRunning ]]; then
+     killall onboard
+  fi
 elif [ "$1" == "-s" ]
 then
   echo "stand-mode"
   xrandr -o inverted
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $inverted
-  xinput disable "$TouchpadDevice"
-  onboard &
+  synclient TouchpadOff=1
+  if [[ -z $isOnboardRunning ]]; then
+     onboard &
+  fi
 elif [ "$1" == "-t" ]
 then
   echo "tablet-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
-  xinput disable "$TouchpadDevice"
-  onboard &
+  synclient TouchpadOff=1
+  if [[ -z $isOnboardRunning ]]; then
+     onboard &
+  fi
 elif [ "$1" == "-tl" ]
 then
   echo "left-mode"
   xrandr -o left
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $left
-  xinput disable "$TouchpadDevice"
-  onboard &
+  synclient TouchpadOff=1
+  if [[ -z $isOnboardRunning ]]; then
+     onboard &
+  fi
 elif [ "$1" == "-tr" ]
 then
   echo "right-mode"
   xrandr -o right
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $right
-  xinput disable "$TouchpadDevice"
-  onboard &
+  synclient TouchpadOff=1
+  if [[ -z $isOnboardRunning ]]; then
+     onboard &
+  fi
 elif [ $screenMatrix == $normal_float ] && [ "$1" == "-key" ]
 then
   echo "left-mode"
   xrandr -o left
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $left
-  xinput disable "$TouchpadDevice"
-  onboard &
+  synclient TouchpadOff=1
+  if [[ -z $isOnboardRunning ]]; then
+     onboard &
+  fi
 else
   echo "laptop-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
   xinput enable "$TouchpadDevice"
-  killall onboard
+  if [[ -n $isOnboardRunning ]]; then
+     killall onboard
+  fi
 fi


### PR DESCRIPTION
In Ubuntu 16.04 the Yoga 3 accelerometer works.
I added a script (and modified yours) in order to get automatic screen rotation.
I also added a suspend/resume script, because otherwise the autorotate.sh script hangs after resume.
