### PR TITLE
revised autorotate script

### DIFF
--- a/99_restart_autorotate
+++ b/99_restart_autorotate
@@ -8,7 +8,7 @@ case $1/$2 in
   post/*)
     echo "Waking up from $2..."
         DISPLAY=:0.0 ; export DISPLAY
-        su $user -c "sleep 5; autorotate.sh &"
+        su $USER -c "sleep 5; autorotate.sh &"
     ;;
 esac
 

--- a/99_restart_autorotate
+++ b/99_restart_autorotate
@@ -2,13 +2,13 @@
 case $1/$2 in
   pre/*)
     echo "Going to $2..."
-    su alberto -c "killall autorotate.sh"
+    su $USER -c "killall autorotate.sh"
     exit 0
     ;;
   post/*)
     echo "Waking up from $2..."
         DISPLAY=:0.0 ; export DISPLAY
-        su alberto -c "sleep 5; autorotate.sh &"
+        su $user -c "sleep 5; autorotate.sh &"
     ;;
 esac
 

--- a/99_restart_autorotate
+++ b/99_restart_autorotate
@@ -2,13 +2,14 @@
 case $1/$2 in
   pre/*)
     echo "Going to $2..."
-    su $USER -c "killall autorotate.sh"
+    killall autorotate.sh
     exit 0
     ;;
   post/*)
     echo "Waking up from $2..."
-        DISPLAY=:0.0 ; export DISPLAY
-        su $USER -c "HOME=/home/$USER autorotate.sh &"
+        killall autorotate.sh
+        sleep 3
+        su root -c "autorotate.sh > /tmp/autorotate.log 2>&1 &"
     ;;
 esac
 

--- a/99_restart_autorotate
+++ b/99_restart_autorotate
@@ -2,7 +2,7 @@
 case $1/$2 in
   pre/*)
     echo "Going to $2..."
-    su alberto -c "killall autorotate.sh"
+    su $USER -c "killall autorotate.sh"
     exit 0
     ;;
   post/*)

--- a/99_restart_autorotate
+++ b/99_restart_autorotate
@@ -1,0 +1,14 @@
+#!/bin/sh
+case $1/$2 in
+  pre/*)
+    echo "Going to $2..."
+    su alberto -c "killall autorotate.sh"
+    exit 0
+    ;;
+  post/*)
+    echo "Waking up from $2..."
+        DISPLAY=:0.0 ; export DISPLAY
+        su alberto -c "sleep 5; autorotate.sh &"
+    ;;
+esac
+

--- a/99_restart_autorotate
+++ b/99_restart_autorotate
@@ -2,13 +2,13 @@
 case $1/$2 in
   pre/*)
     echo "Going to $2..."
-    su $USER -c "killall autorotate.sh"
+    su alberto -c "killall autorotate.sh"
     exit 0
     ;;
   post/*)
     echo "Waking up from $2..."
         DISPLAY=:0.0 ; export DISPLAY
-        su $USER -c "sleep 5; autorotate.sh &"
+        su $USER -c "HOME=/home/$USER autorotate.sh &"
     ;;
 esac
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ installation:
    for lenovo yoga 3 11 you can take Super+O. thats the extra button on the right-hand side, originaly intended 
    to lock automatic screen rotation 
 
+8. edit sudoers file to allow the use of sudo without password for the rmmod and modprobe commands
+
+sudo visudo
+
+add the following lines:
+%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/rmmod
+%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/modprobe
+
 
 blog article (german):                                                                                          
 http://hangg.com/2015/09/ubuntu-screen-rotation-indicator-fuer-lenovo-yoga-3-11/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ installation:
 3. **copy screenrotation.svg to /usr/share/pixmaps/**  
 ~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/
 
-4. **copy configuration files**
+4. **copy configuration files**  
 ~$ sudo mkdir -p /etc/lightdm/lightdm.conf.d  
 ~$ sudo cp autorotate-lightdm.conf /etc/lightdm/lightdm.conf.d  
 ~$ sudo cp blacklist-sensor.conf /etc/modprobe.d

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # screenrotation
 ubuntu unity indicator to rotate the screen for convertibles (like lenovo yoga)
+and autorotate scripts
 
 NOTE: autorotate should work only on Ubuntu 16.04
 
@@ -7,47 +8,40 @@ installation:
 
 1. download file from github and unzip
 
-2. open terminal and cd to file                                                                      
+2. open terminal and cd to file  
 ~$ cd /path/to/screenrotation/
 
-3. copy screenrotation.svg to /usr/share/pixmaps/
-
+3. copy screenrotation.svg to /usr/share/pixmaps/  
 ~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/
 
-4. copy executables to the right directories (please note that first you have to change $USER to your actual user name in 99_restart_autorotate 
+4. copy executables to the right directories (please note that first you have to change $USER to your actual user name in 99_restart_autorotate  
+~$ sudo cp ./autorotate.sh /usr/local/bin  
+~$ sudo cp ./screenrotation.sh /usr/local/bin  
+~$ sudo cp ./screenrotation-indicator.py /usr/local/bin  
+~$ sudo cp ./set_scale.sh /usr/local/bin  
+~$ sudo cp ./99_restart_autorotate /lib/systemd/system-sleep/  
 
-~$ sudo cp ./autorotate.sh /usr/local/bin
-~$ sudo cp ./screenrotation.sh /usr/local/bin
-~$ sudo cp ./screenrotation-indicator.py /usr/local/bin
-~$ sudo cp ./set_scale.sh /usr/local/bin
-~$ sudo cp ./99_restart_autorotate /lib/systemd/system-sleep/
-
-5. make all files executable
-
+5. make all files executable  
 ~$ sudo chmod +x /usr/local/bin/autorotate.sh
 ~$ sudo chmod +x /usr/local/bin/screenrotation-indicator.py
 ~$ sudo chmod +x /usr/local/bin/screenrotation.sh
 ~$ sudo chmod +x /usr/local/bin/set_scale.sh
 ~$ sudo chmod a+x /lib/systemd/system-sleep/99_restart_autorotate
 
-6. add screenrotation-indicator.py and autorotate.sh as startup programs       
+6. add screenrotation-indicator.py and autorotate.sh as startup programs
 
-7. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key] 
-   for lenovo yoga 3 11 you can take Super+O. thats the extra button on the right-hand side, originaly intended to lock automatic screen rotation 
+7. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key]  
+   for lenovo yoga 3 11 you can take Super+O. thats the extra button on the right-hand side, originaly intended to lock automatic screen rotation
 
-8. edit sudoers file to allow the use of sudo without password for the rmmod and modprobe commands
+8. edit sudoers file to allow the use of sudo without password for the rmmod and modprobe commands  
+~$ sudo visudo  
+add the following lines:  
+%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/rmmod  
+%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/modprobe  
 
-~$ sudo visudo
-
-add the following lines:
-%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/rmmod
-%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/modprobe
-
-9. edit blacklist.conf to avoid loading of sensors modules at startup (70% of the times it hangs, we will load it later with autorotate.sh)
-
-~$ sudo nano /etc/modprobe.d/blacklist.conf
-
-add the following line at the end
+9. edit blacklist.conf to avoid loading of sensor kernel module at startup (70% of the times it hangs, we will load it later with autorotate.sh)  
+~$ sudo nano /etc/modprobe.d/blacklist.conf  
+add the following line at the end:  
 blacklist hid_sensor_hub
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # screenrotation
 ubuntu unity indicator to rotate the screen for convertibles (like lenovo yoga)
 
+NOTE: autorotate should work only on Ubuntu 16.04
+
 installation:
 
 1. download file from github and unzip
@@ -11,15 +13,17 @@ installation:
 3. copy screenrotation.svg to /usr/share/pixmaps/                                                              
 ~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/
 
-4. copy screenrotation.sh and screenrotation-indicator.py to /usr/local/bin/                                       
+4. copy autorotate.sh, screenrotation.sh and screenrotation-indicator.py to /usr/local/bin/                                       
+~$ sudo cp ./autorotate.sh /usr/local/bin                                                                    
 ~$ sudo cp ./screenrotation.sh /usr/local/bin                                                                    
 ~$ sudo cp ./screenrotation-indicator.py /usr/local/bin
 
-5. make both files executable                                                                                     
+5. make all files executable                                                                                     
+~$ sudo chmod +x /usr/local/bin/autorotate.sh
 ~$ sudo chmod +x /usr/local/bin/screenrotation-indicator.py                                              
 ~$ sudo chmod +x /usr/local/bin/screenrotation.sh
 
-6. add screenrotation-indicator.py as startup program                                                          
+6. add screenrotation-indicator.py, autorotate.sh as startup programs                                                          
 
 7. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key]                                   
    for lenovo yoga 3 11 you can take Super+O. thats the extra button on the right-hand side, originaly intended 
@@ -32,4 +36,8 @@ http://hangg.com/2015/09/ubuntu-screen-rotation-indicator-fuer-lenovo-yoga-3-11/
 based on:                                                                                                          
 http://askubuntu.com/questions/405628/touchscreen-input-doesnt-rotate-lenovo-yoga-13-yoga-2-pro
 https://gist.github.com/rubo77/daa262e0229f6e398766
+
+Autorotate part based on:
+http://pastebin.com/742KTaS6
+
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ gsettings set org.onboard.auto-show hide-on-key-press true
 gsettings set org.onboard.window docking-enabled true  
 gsettings set org.onboard.window docking-shrink-workarea true  
 gsettings set org.onboard.window force-to-top true  
-gsettings set org.onboard.window.landscape dock-expand true
-gsettings set org.onboard.window.portrait dock-expand true
+gsettings set org.onboard.window.landscape dock-expand true  
+gsettings set org.onboard.window.portrait dock-expand true  
 gsettings set org.onboard.window.landscape dock-height 405  
-gsettings set org.onboard.window.portrait dock-height 405
+gsettings set org.onboard.window.portrait dock-height 405  
 
 Enjoy!
   

--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ installation:
 3. copy screenrotation.svg to /usr/share/pixmaps/                                                              
 ~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/
 
-4. copy autorotate.sh, screenrotation.sh and screenrotation-indicator.py to /usr/local/bin/                                       
-~$ sudo cp ./autorotate.sh /usr/local/bin                                                                    
-~$ sudo cp ./screenrotation.sh /usr/local/bin                                                                    
+4. copy executables to the right directories (please note that first you have to change $USER to your actual user name in 99_restart_autorotate 
+~$ sudo cp ./autorotate.sh /usr/local/bin
+~$ sudo cp ./screenrotation.sh /usr/local/bin
 ~$ sudo cp ./screenrotation-indicator.py /usr/local/bin
+~$ sudo cp ./99_restart_autorotate /lib/systemd/system-sleep/
 
 5. make all files executable                                                                                     
 ~$ sudo chmod +x /usr/local/bin/autorotate.sh
 ~$ sudo chmod +x /usr/local/bin/screenrotation-indicator.py                                              
 ~$ sudo chmod +x /usr/local/bin/screenrotation.sh
+~$ sudo chmod a+x /lib/systemd/system-sleep/99_restart_autorotate
 
 6. add screenrotation-indicator.py, autorotate.sh as startup programs                                                          
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,71 @@
 # screenrotation
-ubuntu unity indicator to rotate the screen for convertibles (like lenovo yoga)
-and autorotate scripts
+Ubuntu Unity indicator to rotate the screen for convertibles like Lenovo Yoga (by Philipp Hangg)  
+and autorotate scripts (by Alberto Pianon)
 
-NOTE: autorotate should work only on Ubuntu 16.04
+**IMPORTANT: autorotate scripts should work only on Ubuntu 16.04, and accelerometer values in autorotate.sh are tweaked for Lenovo Yoga 3 - for other models they may need to be changed**  
+
+*With kernel 4.4 accelerometer sensor module works, but loading it may be an issue (if loaded during a cold boot, very often it freezes the system): however, if it is not loaded on a cold boot but only after a reboot (and only at the end of the reboot process), everything works fine.  
+Until this problem will be fixed, these scripts take care of rebooting the system after a cold boot and then loading the kernel module at the right moment so that it works flawlessly*
 
 installation:
 
 1. download file from github and unzip
 
-2. open terminal and cd to file  
+2. open terminal and cd to directory  
 *~$ cd /path/to/screenrotation/*
 
 3. copy screenrotation.svg to /usr/share/pixmaps/  
 *~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/*
 
-4. copy executables to the right directories (please note that first you have to change $USER to your actual user name in 99_restart_autorotate  
+4. copy configuration files  
+*~$ sudo mkdir -p /etc/lightdm/lightdm.conf.d  
+~$ sudo cp autorotate-lightdm.conf /etc/lightdm/lightdm.conf.d  
+~$ sudo cp blacklist-sensor.conf /etc/modprobe.d
+*
+
+5. copy executables to the right directories  
 *~$ sudo cp ./autorotate.sh /usr/local/bin  
+~$ sudo cp ./accessibility_fix.sh /usr/local/bin  
 ~$ sudo cp ./screenrotation.sh /usr/local/bin  
 ~$ sudo cp ./screenrotation-indicator.py /usr/local/bin  
 ~$ sudo cp ./set_scale.sh /usr/local/bin  
 ~$ sudo cp ./99_restart_autorotate /lib/systemd/system-sleep/*  
 
-5. make all files executable  
-*~$ sudo chmod +x /usr/local/bin/autorotate.sh
-~$ sudo chmod +x /usr/local/bin/screenrotation-indicator.py
-~$ sudo chmod +x /usr/local/bin/screenrotation.sh
-~$ sudo chmod +x /usr/local/bin/set_scale.sh
+6. make all files executable  
+*~$ sudo chmod +x /usr/local/bin/\*  
 ~$ sudo chmod a+x /lib/systemd/system-sleep/99_restart_autorotate*
 
-6. edit sudoers file to allow the use of sudo without password for the rmmod and modprobe commands  
-*~$ sudo visudo*  
-add the following lines:  
-*%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/rmmod  
-%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/modprobe*  
+7. add screenrotation-indicator.py as startup program
 
-7. edit blacklist.conf to <u>avoid loading of sensor kernel module at startup</u> (70% of the times it hangs, we will load it later with autorotate.sh)  
-*~$ sudo nano /etc/modprobe.d/blacklist.conf*  
-add the following line at the end:  
-*blacklist hid_sensor_hub*
-
-8. add screenrotation-indicator.py and autorotate.sh as startup programs
-
-9. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key]  
+8. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key]  
    for lenovo yoga 3 11 you can take Super+O. thats the extra button on the right-hand side, originaly intended to lock automatic screen rotation
 
 
-**Some footnotes:**  
+**How to make the screen autorotate service work correctly:**  
 
-* <u>sleep times in autorotate.sh are necessary</u>, otherwise the sensor kernel module may hang or crash the system
+* at the end of a cold boot, when you see the dialog box, you have to click on "Reboot"; at the end of the reboot process, you have instead to click on "Proceed"
+* in this way, the accelerometer kernel module is fairly stable, and almost never crashes (if it happens, the autorotate script displays a notificaton)
 
-* <u>autorotate.sh needs to be killed before suspend and restarted after resume</u> otherwise it may hang, so the script  99_restart_autorotate is necessary
+** Onboard tweaks **  
+  
+note: enabling tooltips is required to have the close ("x") button in the "Small" layout
 
-* <u>it is necessary to put gsettings command in a separate script (set_scale.sh)</u>, otherwise it does not work after suspend/resume (gsettings does not work if called with su, so we cannot put it in autorotate.sh, which is restarted after resume with "su $USER -c autorotate.sh" in the 99_restart_autorotate script)
+*gsettings set org.onboard layout /usr/share/onboard/layouts/Small.onboard  
+gsettings set org.onboard show-tooltips true  
+gsettings set org.onboard.auto-show enabled true  
+gsettings set org.onboard.auto-show hide-on-key-press true  
+gsettings set org.onboard.window docking-enabled true  
+gsettings set org.onboard.window docking-shrink-workarea true  
+gsettings set org.onboard.window force-to-top true  
+gsettings set org.onboard.window.landscape dock-expand true
+gsettings set org.onboard.window.portrait dock-expand true
+gsettings set org.onboard.window.landscape dock-height 405  
+gsettings set org.onboard.window.portrait dock-height 405*  
 
-
+Enjoy!
+  
+---
+  
 blog article (german):                                                                                          
 http://hangg.com/2015/09/ubuntu-screen-rotation-indicator-fuer-lenovo-yoga-3-11/
 

--- a/README.md
+++ b/README.md
@@ -9,40 +9,49 @@ installation:
 1. download file from github and unzip
 
 2. open terminal and cd to file  
-~$ cd /path/to/screenrotation/
+*~$ cd /path/to/screenrotation/*
 
 3. copy screenrotation.svg to /usr/share/pixmaps/  
-~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/
+*~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/*
 
 4. copy executables to the right directories (please note that first you have to change $USER to your actual user name in 99_restart_autorotate  
-~$ sudo cp ./autorotate.sh /usr/local/bin  
+*~$ sudo cp ./autorotate.sh /usr/local/bin  
 ~$ sudo cp ./screenrotation.sh /usr/local/bin  
 ~$ sudo cp ./screenrotation-indicator.py /usr/local/bin  
 ~$ sudo cp ./set_scale.sh /usr/local/bin  
-~$ sudo cp ./99_restart_autorotate /lib/systemd/system-sleep/  
+~$ sudo cp ./99_restart_autorotate /lib/systemd/system-sleep/*  
 
 5. make all files executable  
-~$ sudo chmod +x /usr/local/bin/autorotate.sh
+*~$ sudo chmod +x /usr/local/bin/autorotate.sh
 ~$ sudo chmod +x /usr/local/bin/screenrotation-indicator.py
 ~$ sudo chmod +x /usr/local/bin/screenrotation.sh
 ~$ sudo chmod +x /usr/local/bin/set_scale.sh
-~$ sudo chmod a+x /lib/systemd/system-sleep/99_restart_autorotate
+~$ sudo chmod a+x /lib/systemd/system-sleep/99_restart_autorotate*
 
-6. add screenrotation-indicator.py and autorotate.sh as startup programs
+6. edit sudoers file to allow the use of sudo without password for the rmmod and modprobe commands  
+*~$ sudo visudo*  
+add the following lines:  
+*%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/rmmod  
+%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/modprobe*  
 
-7. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key]  
+7. edit blacklist.conf to <u>avoid loading of sensor kernel module at startup</u> (70% of the times it hangs, we will load it later with autorotate.sh)  
+*~$ sudo nano /etc/modprobe.d/blacklist.conf*  
+add the following line at the end:  
+*blacklist hid_sensor_hub*
+
+8. add screenrotation-indicator.py and autorotate.sh as startup programs
+
+9. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key]  
    for lenovo yoga 3 11 you can take Super+O. thats the extra button on the right-hand side, originaly intended to lock automatic screen rotation
 
-8. edit sudoers file to allow the use of sudo without password for the rmmod and modprobe commands  
-~$ sudo visudo  
-add the following lines:  
-%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/rmmod  
-%sudo ALL=(ALL:ALL) NOPASSWD: /sbin/modprobe  
 
-9. edit blacklist.conf to avoid loading of sensor kernel module at startup (70% of the times it hangs, we will load it later with autorotate.sh)  
-~$ sudo nano /etc/modprobe.d/blacklist.conf  
-add the following line at the end:  
-blacklist hid_sensor_hub
+**Some footnotes:**  
+
+* <u>sleep times in autorotate.sh are necessary</u>, otherwise the sensor kernel module may hang or crash the system
+
+* <u>autorotate.sh needs to be killed before suspend and restarted after resume</u> otherwise it may hang, so the script  99_restart_autorotate is necessary
+
+* <u>it is necessary to put gsettings command in a separate script (set_scale.sh)</u>, otherwise it does not work after suspend/resume (gsettings does not work if called with su, so we cannot put it in autorotate.sh, which is restarted after resume with "su $USER -c autorotate.sh" in the 99_restart_autorotate script)
 
 
 blog article (german):                                                                                          

--- a/README.md
+++ b/README.md
@@ -10,34 +10,45 @@ installation:
 2. open terminal and cd to file                                                                      
 ~$ cd /path/to/screenrotation/
 
-3. copy screenrotation.svg to /usr/share/pixmaps/                                                              
+3. copy screenrotation.svg to /usr/share/pixmaps/
+
 ~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/
 
 4. copy executables to the right directories (please note that first you have to change $USER to your actual user name in 99_restart_autorotate 
+
 ~$ sudo cp ./autorotate.sh /usr/local/bin
 ~$ sudo cp ./screenrotation.sh /usr/local/bin
 ~$ sudo cp ./screenrotation-indicator.py /usr/local/bin
+~$ sudo cp ./set_scale.sh /usr/local/bin
 ~$ sudo cp ./99_restart_autorotate /lib/systemd/system-sleep/
 
-5. make all files executable                                                                                     
+5. make all files executable
+
 ~$ sudo chmod +x /usr/local/bin/autorotate.sh
-~$ sudo chmod +x /usr/local/bin/screenrotation-indicator.py                                              
+~$ sudo chmod +x /usr/local/bin/screenrotation-indicator.py
 ~$ sudo chmod +x /usr/local/bin/screenrotation.sh
+~$ sudo chmod +x /usr/local/bin/set_scale.sh
 ~$ sudo chmod a+x /lib/systemd/system-sleep/99_restart_autorotate
 
-6. add screenrotation-indicator.py, autorotate.sh as startup programs                                                          
+6. add screenrotation-indicator.py and autorotate.sh as startup programs       
 
-7. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key]                                   
-   for lenovo yoga 3 11 you can take Super+O. thats the extra button on the right-hand side, originaly intended 
-   to lock automatic screen rotation 
+7. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key] 
+   for lenovo yoga 3 11 you can take Super+O. thats the extra button on the right-hand side, originaly intended to lock automatic screen rotation 
 
 8. edit sudoers file to allow the use of sudo without password for the rmmod and modprobe commands
 
-sudo visudo
+~$ sudo visudo
 
 add the following lines:
 %sudo ALL=(ALL:ALL) NOPASSWD: /sbin/rmmod
 %sudo ALL=(ALL:ALL) NOPASSWD: /sbin/modprobe
+
+9. edit blacklist.conf to avoid loading of sensors modules at startup (70% of the times it hangs, we will load it later with autorotate.sh)
+
+~$ sudo nano /etc/modprobe.d/blacklist.conf
+
+add the following line at the end
+blacklist hid_sensor_hub
 
 
 blog article (german):                                                                                          

--- a/README.md
+++ b/README.md
@@ -9,35 +9,34 @@ Until this problem will be fixed, these scripts take care of rebooting the syste
 
 installation:
 
-1. download file from github and unzip
+1. **download file from github and unzip**
 
-2. open terminal and cd to directory  
-*~$ cd /path/to/screenrotation/*
+2. **open terminal and cd to directory**  
+~$ cd /path/to/screenrotation/
 
-3. copy screenrotation.svg to /usr/share/pixmaps/  
-*~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/*
+3. **copy screenrotation.svg to /usr/share/pixmaps/**  
+~$ sudo cp ./screenrotation.svg /usr/share/pixmaps/
 
-4. copy configuration files  
-*~$ sudo mkdir -p /etc/lightdm/lightdm.conf.d  
+4. **copy configuration files**
+~$ sudo mkdir -p /etc/lightdm/lightdm.conf.d  
 ~$ sudo cp autorotate-lightdm.conf /etc/lightdm/lightdm.conf.d  
 ~$ sudo cp blacklist-sensor.conf /etc/modprobe.d
-*
 
-5. copy executables to the right directories  
-*~$ sudo cp ./autorotate.sh /usr/local/bin  
+5. **copy executables to the right directories**  
+~$ sudo cp ./autorotate.sh /usr/local/bin  
 ~$ sudo cp ./accessibility_fix.sh /usr/local/bin  
 ~$ sudo cp ./screenrotation.sh /usr/local/bin  
 ~$ sudo cp ./screenrotation-indicator.py /usr/local/bin  
 ~$ sudo cp ./set_scale.sh /usr/local/bin  
-~$ sudo cp ./99_restart_autorotate /lib/systemd/system-sleep/*  
+~$ sudo cp ./99_restart_autorotate /lib/systemd/system-sleep
 
-6. make all files executable  
-*~$ sudo chmod +x /usr/local/bin/\*  
-~$ sudo chmod a+x /lib/systemd/system-sleep/99_restart_autorotate*
+6. **make all files executable**  
+~$ sudo chmod +x /usr/local/bin/*  
+~$ sudo chmod a+x /lib/systemd/system-sleep/99_restart_autorotate
 
-7. add screenrotation-indicator.py as startup program
+7. **add screenrotation-indicator.py as startup program**
 
-8. add keyboard-shortcut  command: [/usr/local/bin/screenrotation.sh -key]  
+8. **add keyboard-shortcut**  command: [/usr/local/bin/screenrotation.sh -key]  
    for lenovo yoga 3 11 you can take Super+O. thats the extra button on the right-hand side, originaly intended to lock automatic screen rotation
 
 
@@ -46,11 +45,11 @@ installation:
 * at the end of a cold boot, when you see the dialog box, you have to click on "Reboot"; at the end of the reboot process, you have instead to click on "Proceed"
 * in this way, the accelerometer kernel module is fairly stable, and almost never crashes (if it happens, the autorotate script displays a notificaton)
 
-** Onboard tweaks **  
+**Onboard tweaks**  
   
 note: enabling tooltips is required to have the close ("x") button in the "Small" layout
 
-*gsettings set org.onboard layout /usr/share/onboard/layouts/Small.onboard  
+gsettings set org.onboard layout /usr/share/onboard/layouts/Small.onboard  
 gsettings set org.onboard show-tooltips true  
 gsettings set org.onboard.auto-show enabled true  
 gsettings set org.onboard.auto-show hide-on-key-press true  
@@ -60,7 +59,7 @@ gsettings set org.onboard.window force-to-top true
 gsettings set org.onboard.window.landscape dock-expand true
 gsettings set org.onboard.window.portrait dock-expand true
 gsettings set org.onboard.window.landscape dock-height 405  
-gsettings set org.onboard.window.portrait dock-height 405*  
+gsettings set org.onboard.window.portrait dock-height 405
 
 Enjoy!
   

--- a/accessibility_fix.sh
+++ b/accessibility_fix.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# when a user logs in, accessibility service run as root must be killed
+# otherwise onboard does not work
+killall at-spi-bus-launcher
+killall at-spi2-registry
+exit 0

--- a/autorotate-lightdm.conf
+++ b/autorotate-lightdm.conf
@@ -1,0 +1,3 @@
+[Seat:*]
+display-setup-script=su root -c "start_autorotate.sh"
+session-setup-script=su root -c "accessibility_fix.sh"

--- a/autorotate.sh
+++ b/autorotate.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#(C) Alberto Pianon, April 2016
+# licensed under MIT license
+#
+# based on: http://pastebin.com/742KTaS6
+#
+# Works for Lenovo Yoga 3 11, Ubuntu 16.04 (tested on 64bit version)
+# (does not work for Ubuntu previous versions)
+#
+# IMPORTANT: this script should never be killed and restarted,
+# otherwise for some reason the kernel module may hang
+
+echo "Autorotate" > $HOME/.screen_orientation
+
+xpath=`find /sys/devices/pci0000:00 | grep in_accel_x_raw`
+ypath=`find /sys/devices/pci0000:00 | grep in_accel_y_raw`
+
+if [[ -z $xpath ]]; then
+  zenity --error --text="ERROR: accelerometer not detected by linux kernel"
+  exit 1
+fi
+
+
+current_case=0
+counter=0
+num_iterations=2
+max_iterations=4
+ 
+function increaseCounter
+{
+    c=$1
+    if [[ $c -eq $current_case ]]; then
+        counter=$((counter + 1))
+    else
+        current_case=$c
+        counter=1
+    fi
+}
+ 
+sleep 1
+ 
+while true; do
+ 
+  HDMIConn=`xrandr --query | grep "HDMI1 connected"`
+  if [[ $HDMIConn ]]; then
+      #echo -en "\rHDMI connected, no rotation";
+      HDMIConn=""
+      continue
+  fi 
+  
+  response_time=`/usr/bin/time -f "%e" cat "$xpath" 2>&1 | sed -n 2p`
+
+  if (( `echo "$response_time > 1" | bc -l` )); then
+    zenity --error --text="ERROR: accelerometer kernel module hanging, please restart computer"
+    exit 1
+  fi
+
+  x=`cat "$xpath"`
+  y=`cat "$ypath"`
+
+
+  o=`cat $HOME/.screen_orientation`
+
+
+    if [[ ($x -gt 65400 && $y -gt 50000 && $o == "Autorotate") || $o == "Laptop-Mode" ]]; then
+        increaseCounter 0
+        if [[ $counter -gt $num_iterations && $counter -lt $max_iterations ]]; then
+        screenrotation.sh -l
+        fi
+    fi
+    
+    if [[ ($x -lt 1100 && $x -gt 500 && ($y -lt 701 || $y -gt 5000) && $o == "Autorotate") || $o == "Tablet-Left-Mode" ]]; then
+        increaseCounter 3
+        if [[ $counter -gt $num_iterations && $counter -lt $max_iterations ]]; then
+        screenrotation.sh -tl
+        fi
+    fi
+
+    if [[ (($x -gt 50000  || $x -lt 1100) && $y -gt 700 && $y -lt 1100 && $o == "Autorotate") || $o == "Stand-Mode" ]]; then
+        increaseCounter 2
+        if [[ $counter -gt $num_iterations && $counter -lt $max_iterations ]]; then
+        screenrotation.sh -s
+        fi
+    fi
+
+    if [[ ($x -gt 50000 && $x -lt 65401 && $y -lt 300 && $o == "Autorotate") || $o == "Tablet-Right-Mode"  ]]; then
+        increaseCounter 1
+        if [[ $counter -gt $num_iterations && $counter -lt $max_iterations ]]; then
+          screenrotation.sh -tr
+        fi
+    fi
+    
+    if [[ $o == "Tablet-Mode" ]]; then
+        increaseCounter 4
+        if [[ $counter -gt $num_iterations && $counter -lt $max_iterations ]]; then
+          screenrotation.sh -t
+        fi
+    fi
+  
+  sleep 0.05
+
+done

--- a/autorotate.sh
+++ b/autorotate.sh
@@ -8,6 +8,7 @@
 # (does not work for Ubuntu previous versions)
 #
 # IMPORTANT: this script should never be killed and restarted,
+# (unles when suspending and resuming)
 # otherwise for some reason the kernel module may hang
 
 echo "Autorotate" > $HOME/.screen_orientation

--- a/autorotate.sh
+++ b/autorotate.sh
@@ -7,11 +7,15 @@
 # Works for Lenovo Yoga 3 11, Ubuntu 16.04 (tested on 64bit version)
 # (does not work for Ubuntu previous versions)
 
+   sleep 8
+   sudo modprobe hid_sensor_hub
+   sleep 5
+
 function restartSensorModules
 {
-   rmmod hid_sensor_gyro_3d hid_sensor_incl_3d hid_sensor_accel_3d hid_sensor_rotation hid_sensor_als hid_sensor_magn_3d hid_sensor_trigger hid_sensor_iio_common hid_sensor_custom hid_sensor_hub
+   sudo rmmod hid_sensor_gyro_3d hid_sensor_incl_3d hid_sensor_accel_3d hid_sensor_rotation hid_sensor_als hid_sensor_magn_3d hid_sensor_trigger hid_sensor_iio_common hid_sensor_custom hid_sensor_hub
    sleep 1
-   modprobe hid_sensor_hub
+   sudo modprobe hid_sensor_hub
 }
 
 echo "Autorotate" > $HOME/.screen_orientation
@@ -46,6 +50,8 @@ function increaseCounter
 }
  
 sleep 1
+
+zenity --info --text="starting screen autorotation service" &
  
 while true; do
  

--- a/autorotate.sh
+++ b/autorotate.sh
@@ -4,40 +4,24 @@
 #
 # based on: http://pastebin.com/742KTaS6
 #
-# Works for Lenovo Yoga 3 11, Ubuntu 16.04 (tested on 64bit version)
+# Tested on Lenovo Yoga 3 11, Ubuntu 16.04 (64bit)
 # (does not work for Ubuntu previous versions)
 
-   sleep 8
-   sudo modprobe hid_sensor_hub
-   sleep 5
+function zenityNotification
+{
+   echo "message:$1" | zenity --notification --listen &
+   mypid=$!
+   sleep 0.5
+   kill $mypid
+}
 
 function restartSensorModules
 {
-   sudo rmmod hid_sensor_gyro_3d hid_sensor_incl_3d hid_sensor_accel_3d hid_sensor_rotation hid_sensor_als hid_sensor_magn_3d hid_sensor_trigger hid_sensor_iio_common hid_sensor_custom hid_sensor_hub
+   rmmod hid_sensor_gyro_3d hid_sensor_incl_3d hid_sensor_accel_3d hid_sensor_rotation hid_sensor_als hid_sensor_magn_3d hid_sensor_trigger hid_sensor_iio_common hid_sensor_custom hid_sensor_hub
    sleep 1
-   sudo modprobe hid_sensor_hub
+   modprobe hid_sensor_hub
 }
 
-echo "Autorotate" > $HOME/.screen_orientation
-
-xpath=`find /sys/devices/pci0000:00 | grep in_accel_x_raw`
-ypath=`find /sys/devices/pci0000:00 | grep in_accel_y_raw`
-
-if [[ -z $xpath ]]; then
-  restartSensorModules
-  xpath=`find /sys/devices/pci0000:00 | grep in_accel_x_raw`
-  if [[ -z $xpath ]]; then
-     zenity --error --text="ERROR: accelerometer not detected by linux kernel"
-     exit 1
-  fi
-fi
-
-
-current_case=0
-counter=0
-num_iterations=2
-max_iterations=4
- 
 function increaseCounter
 {
     c=$1
@@ -48,16 +32,40 @@ function increaseCounter
         counter=1
     fi
 }
+
+export DISPLAY=":0.0"
+xhost local:root
+
+tmpdir="/tmp/screen_management"
+
+xpath=`find /sys/devices/pci0000:00 | grep in_accel_x_raw`
+
+if [[ -z $xpath ]]; then
+  restartSensorModules
+  xpath=`find /sys/devices/pci0000:00 | grep in_accel_x_raw`
+  if [[ -z $xpath ]]; then
+     zenityNotification "ERROR: accelerometer not detected by linux kernel"
+     exit 1
+  fi
+fi
+
+ypath=`find /sys/devices/pci0000:00 | grep in_accel_y_raw`
+
+
+current_case=0
+counter=0
+num_iterations=2
+max_iterations=4
  
 sleep 1
 
-zenity --info --text="starting screen autorotation service" &
+zenityNotification "screen autorotation service started"
  
 while true; do
  
   HDMIConn=`xrandr --query | grep "HDMI1 connected"`
   if [[ $HDMIConn ]]; then
-      #echo -en "\rHDMI connected, no rotation";
+      #HDMI connected, no rotation
       HDMIConn=""
       continue
   fi 
@@ -68,7 +76,7 @@ while true; do
     restartSensorModules
     xpath=`find /sys/devices/pci0000:00 | grep in_accel_x_raw`
     if [[ -z $xpath ]]; then
-      zenity --error --text="ERROR: accelerometer kernel not working, please restart computer"
+      zenityNotification "ERROR: accelerometer kernel module not working\nscreen autorotate cannot work"
       exit 1
     fi    
   fi
@@ -77,7 +85,7 @@ while true; do
   y=`cat "$ypath"`
 
 
-  o=`cat $HOME/.screen_orientation`
+  o=`cat $tmpdir/screen_orientation`
 
 
     if [[ ($x -gt 65400 && $y -gt 50000 && $o == "Autorotate") || $o == "Laptop-Mode" ]]; then

--- a/blacklist-sensor.conf
+++ b/blacklist-sensor.conf
@@ -1,0 +1,3 @@
+# working but unstable in kernel 4.4, we have to load it after a reboot
+blacklist hid_sensor_hub
+

--- a/screenrotation-indicator.py
+++ b/screenrotation-indicator.py
@@ -11,6 +11,7 @@ APPINDICATOR_ID = 'screenrotationindicator'
 menu_items = {}
 
 os.system('echo "Autorotate" > $HOME/.screen_orientation')
+os.system('set_scale.sh &')
 
 def main():
     indicator = appindicator.Indicator.new(APPINDICATOR_ID, '/usr/share/pixmaps/screenrotation.svg', appindicator.IndicatorCategory.SYSTEM_SERVICES)

--- a/screenrotation-indicator.py
+++ b/screenrotation-indicator.py
@@ -8,6 +8,10 @@ from gi.repository import Notify as notify
 
 APPINDICATOR_ID = 'screenrotationindicator'
 
+menu_items = {}
+
+os.system('echo "Autorotate" > $HOME/.screen_orientation')
+
 def main():
     indicator = appindicator.Indicator.new(APPINDICATOR_ID, '/usr/share/pixmaps/screenrotation.svg', appindicator.IndicatorCategory.SYSTEM_SERVICES)
     indicator.set_status(appindicator.IndicatorStatus.ACTIVE)
@@ -16,61 +20,37 @@ def main():
     gtk.main()
 
 def build_menu():
-	menu = gtk.Menu()	
-	#laptop-mode
-	item_laptop_mode = gtk.MenuItem('Laptop-Mode')
-	item_laptop_mode.connect('activate', laptopmode)
-	menu.append(item_laptop_mode)
-	#stand-mode
-	item_stand_mode = gtk.MenuItem('Stand-Mode')
-	item_stand_mode.connect('activate', standmode)
-	menu.append(item_stand_mode)
-	#tablet-mode
-	item_tablet_mode = gtk.MenuItem('Tablet-Mode')
-	item_tablet_mode.connect('activate', tabletmode)
-	menu.append(item_tablet_mode)
-	#tablet-left-mode
-	item_tablet_left_mode = gtk.MenuItem('Tablet-Left-Mode')
-	item_tablet_left_mode.connect('activate', tabletleftmode)
-	menu.append(item_tablet_left_mode)
-	#tablet-right-mode
-	item_tablet_right_mode = gtk.MenuItem('Tablet-Right-Mode')
-	item_tablet_right_mode.connect('activate', tabletrightmode)
-	menu.append(item_tablet_right_mode)
-	# quit
-	item_quit = gtk.MenuItem('Quit')
-	item_quit.connect('activate', quit)
-	menu.append(item_quit)
-	menu.show_all()
-	return menu
+   global menu_items
+   menu = gtk.Menu()
+   group = []
+   menu_arr = [
+      'Autorotate', 'Laptop-Mode', 'Stand-Mode', 
+      'Tablet-Mode', 'Tablet-Left-Mode', 'Tablet-Right-Mode'
+   ]
+   for i in range(len(menu_arr)):
+      menu_item = gtk.RadioMenuItem.new_with_label(group, menu_arr[i])
+      group = menu_item.get_group()
+      menu_items[menu_arr[i]] = menu_item      
+      menu.append(menu_item)
+      menu_item.connect("activate", on_menu_select, menu_arr[i])
+   
+   # quit
+   item_quit = gtk.MenuItem('Quit')
+   item_quit.connect('activate', quit)
+   menu.append(item_quit)
+   menu.show_all()
+   return menu
 
-# laptopmode funktion
-def laptopmode(_):
-    notify.Notification.new("Laptop-Mode", None).show()
-    os.system('screenrotation.sh -l')
 
-# standmode funktion
-def standmode(_):
-    notify.Notification.new("Stand-Mode", None).show()
-    os.system('screenrotation.sh -s')    
+def on_menu_select(obj, label):
+   global menu_items
+   if menu_items[label].get_active():
+      notify.Notification.new(label, None).show()
+      os.system('echo "'+label+'" > $HOME/.screen_orientation')
 
-# ltabletmode funktion
-def tabletmode(_):
-    notify.Notification.new("Tablet-Mode", None).show()
-    os.system('screenrotation.sh -t')
-
-# tabletleftmode funktion
-def tabletleftmode(_):
-    notify.Notification.new("Tablet-Left-Mode", None).show()
-    os.system('screenrotation.sh -tl')
-
-# tabletrightmode funktion
-def tabletrightmode(_):
-    notify.Notification.new("Tablet-Right-Mode", None).show()
-    os.system('screenrotation.sh -tr')
-
-# quit funktion
+# quit function
 def quit(_):
+	os.system('echo "laptop" > $HOME/.screen_orientation')
 	notify.uninit() 
 	gtk.main_quit()
 

--- a/screenrotation-indicator.py
+++ b/screenrotation-indicator.py
@@ -10,8 +10,8 @@ APPINDICATOR_ID = 'screenrotationindicator'
 
 menu_items = {}
 
-os.system('echo "Autorotate" > $HOME/.screen_orientation')
-os.system('set_scale.sh &')
+os.system('echo "Autorotate" > /tmp/screen_management/screen_orientation')
+os.system('killall set_scale.sh; set_scale.sh &')
 
 def main():
     indicator = appindicator.Indicator.new(APPINDICATOR_ID, '/usr/share/pixmaps/screenrotation.svg', appindicator.IndicatorCategory.SYSTEM_SERVICES)
@@ -47,11 +47,11 @@ def on_menu_select(obj, label):
    global menu_items
    if menu_items[label].get_active():
       notify.Notification.new(label, None).show()
-      os.system('echo "'+label+'" > $HOME/.screen_orientation')
+      os.system('echo "'+label+'" > /tmp/screen_management/screen_orientation')
 
 # quit function
 def quit(_):
-	os.system('echo "laptop" > $HOME/.screen_orientation')
+	os.system('echo "Laptop-Mode" > /tmp/screen_management/screen_orientation')
 	notify.uninit() 
 	gtk.main_quit()
 

--- a/screenrotation.sh
+++ b/screenrotation.sh
@@ -116,7 +116,7 @@ else
   echo "laptop-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
-  xinput enable "$TouchpadDevice"
+  synclient TouchpadOff=0
   if [[ -n $isOnboardRunning ]]; then
      killall onboard
   fi

--- a/screenrotation.sh
+++ b/screenrotation.sh
@@ -6,6 +6,30 @@
 
 #### configuration
 # find your Touchscreen and Touchpad device with the command `xinput`
+
+function set_screen
+{
+   isOnboardRunning=`ps -A | grep onboard`
+   case "$1" in
+        normal)
+           synclient TouchpadOff=0
+           if [[ -n $isOnboardRunning ]]; then
+              killall onboard
+           fi
+           echo "normal" > $HOME/.screen_scale
+           ;;
+        touchscreen)
+           synclient TouchpadOff=1
+           if [[ -z $isOnboardRunning ]]; then
+              onboard &
+           fi
+           echo "touchscreen" > $HOME/.screen_scale
+           ;; 
+   esac
+}
+
+
+
 TouchscreenDevice='ELAN Touchscreen'
 
 if [ "$1" = "--help"  ] || [ "$1" = "-h"  ] ; then
@@ -56,68 +80,47 @@ left_float='0.000000,-1.000000,1.000000,1.000000,0.000000,0.000000,0.000000,0.00
 #⎣  0 0 1 ⎦
 right='0 1 0 -1 0 1 0 0 1'
 
-isOnboardRunning=`ps -A | grep onboard`
+
 
 if [ "$1" == "-l" ]
 then
   echo "laptop-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
-  synclient TouchpadOff=0
-  if [[ -n $isOnboardRunning ]]; then
-     killall onboard
-  fi
+  set_screen normal
 elif [ "$1" == "-s" ]
 then
   echo "stand-mode"
   xrandr -o inverted
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $inverted
-  synclient TouchpadOff=1
-  if [[ -z $isOnboardRunning ]]; then
-     onboard &
-  fi
+  set_screen touchscreen
 elif [ "$1" == "-t" ]
 then
   echo "tablet-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
-  synclient TouchpadOff=1
-  if [[ -z $isOnboardRunning ]]; then
-     onboard &
-  fi
+  set_screen touchscreen
 elif [ "$1" == "-tl" ]
 then
   echo "left-mode"
   xrandr -o left
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $left
-  synclient TouchpadOff=1
-  if [[ -z $isOnboardRunning ]]; then
-     onboard &
-  fi
+  set_screen touchscreen
 elif [ "$1" == "-tr" ]
 then
   echo "right-mode"
   xrandr -o right
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $right
-  synclient TouchpadOff=1
-  if [[ -z $isOnboardRunning ]]; then
-     onboard &
-  fi
+  set_screen touchscreen
 elif [ $screenMatrix == $normal_float ] && [ "$1" == "-key" ]
 then
   echo "left-mode"
   xrandr -o left
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $left
-  synclient TouchpadOff=1
-  if [[ -z $isOnboardRunning ]]; then
-     onboard &
-  fi
+  set_screen touchscreen
 else
   echo "laptop-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
-  synclient TouchpadOff=0
-  if [[ -n $isOnboardRunning ]]; then
-     killall onboard
-  fi
+  set_screen normal
 fi

--- a/screenrotation.sh
+++ b/screenrotation.sh
@@ -9,21 +9,15 @@
 
 function set_screen
 {
-   isOnboardRunning=`ps -A | grep onboard`
+   tmpdir="/tmp/screen_management"
    case "$1" in
         normal)
            synclient TouchpadOff=0
-           if [[ -n $isOnboardRunning ]]; then
-              killall onboard
-           fi
-           echo "normal" > $HOME/.screen_scale
+           echo "normal" > $tmpdir/screen_scale
            ;;
         touchscreen)
            synclient TouchpadOff=1
-           if [[ -z $isOnboardRunning ]]; then
-              onboard &
-           fi
-           echo "touchscreen" > $HOME/.screen_scale
+           echo "touchscreen" > $tmpdir/screen_scale
            ;; 
    esac
 }

--- a/screenrotation.sh
+++ b/screenrotation.sh
@@ -7,7 +7,6 @@
 #### configuration
 # find your Touchscreen and Touchpad device with the command `xinput`
 TouchscreenDevice='ELAN Touchscreen'
-TouchpadDevice='SYNA2B23:00 06CB:2714'
 
 if [ "$1" = "--help"  ] || [ "$1" = "-h"  ] ; then
 echo 'Usage: screenrotation.sh [OPTION]'
@@ -26,7 +25,6 @@ echo ' -key tablet-left-mode (set keyboard shortcut): screen 90° left, touchpad
 exit 0
 fi
 
-touchpadEnabled=$(xinput --list-props "$TouchpadDevice" | awk '/Device Enabled/{print $NF}')
 screenMatrix=$(xinput --list-props "$TouchscreenDevice" | awk '/Coordinate Transformation Matrix/{print $5$6$7$8$9$10$11$12$NF}')
 
 # Matrix for rotation
@@ -58,53 +56,68 @@ left_float='0.000000,-1.000000,1.000000,1.000000,0.000000,0.000000,0.000000,0.00
 #⎣  0 0 1 ⎦
 right='0 1 0 -1 0 1 0 0 1'
 
+isOnboardRunning=`ps -A | grep onboard`
 
 if [ "$1" == "-l" ]
 then
   echo "laptop-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
-  xinput enable "$TouchpadDevice"
-  killall onboard
+  synclient TouchpadOff=0
+  if [[ -n $isOnboardRunning ]]; then
+     killall onboard
+  fi
 elif [ "$1" == "-s" ]
 then
   echo "stand-mode"
   xrandr -o inverted
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $inverted
-  xinput disable "$TouchpadDevice"
-  onboard &
+  synclient TouchpadOff=1
+  if [[ -z $isOnboardRunning ]]; then
+     onboard &
+  fi
 elif [ "$1" == "-t" ]
 then
   echo "tablet-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
-  xinput disable "$TouchpadDevice"
-  onboard &
+  synclient TouchpadOff=1
+  if [[ -z $isOnboardRunning ]]; then
+     onboard &
+  fi
 elif [ "$1" == "-tl" ]
 then
   echo "left-mode"
   xrandr -o left
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $left
-  xinput disable "$TouchpadDevice"
-  onboard &
+  synclient TouchpadOff=1
+  if [[ -z $isOnboardRunning ]]; then
+     onboard &
+  fi
 elif [ "$1" == "-tr" ]
 then
   echo "right-mode"
   xrandr -o right
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $right
-  xinput disable "$TouchpadDevice"
-  onboard &
+  synclient TouchpadOff=1
+  if [[ -z $isOnboardRunning ]]; then
+     onboard &
+  fi
 elif [ $screenMatrix == $normal_float ] && [ "$1" == "-key" ]
 then
   echo "left-mode"
   xrandr -o left
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $left
-  xinput disable "$TouchpadDevice"
-  onboard &
+  synclient TouchpadOff=1
+  if [[ -z $isOnboardRunning ]]; then
+     onboard &
+  fi
 else
   echo "laptop-mode"
   xrandr -o normal
   xinput set-prop "$TouchscreenDevice" 'Coordinate Transformation Matrix' $normal
   xinput enable "$TouchpadDevice"
-  killall onboard
+  if [[ -n $isOnboardRunning ]]; then
+     killall onboard
+  fi
 fi

--- a/set_scale.sh
+++ b/set_scale.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 old_screen_scale=""
+tmpdir="/tmp/screen_management"
 
 while true; do
-   if [ -a $HOME/.screen_scale ]; then
-      screen_scale=`cat $HOME/.screen_scale`
+   if [ -a $tmpdir/screen_scale ]; then
+      screen_scale=`cat $tmpdir/screen_scale`
    else
       continue
    fi
-
+   
+   isOnboardRunning=`ps -A | grep onboard`
    normal_scale=8
    touchscreen_scale=12
    if [ "$old_screen_scale" != "$screen_scale" ]; then
@@ -15,10 +17,16 @@ while true; do
       echo $screen_scale
       case "$screen_scale" in
          normal)
+           if [[ -n $isOnboardRunning ]]; then
+              killall onboard
+           fi
            gsettings set com.ubuntu.user-interface scale-factor "{'eDP1': $normal_scale}"
            ;;
          touchscreen)
            gsettings set com.ubuntu.user-interface scale-factor "{'eDP1': $touchscreen_scale}"
+           if [[ -z $isOnboardRunning ]]; then
+              onboard &
+           fi
            ;;
       esac
    fi

--- a/set_scale.sh
+++ b/set_scale.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+old_screen_scale=""
+
+while true; do
+   if [ -a $HOME/.screen_scale ]; then
+      screen_scale=`cat $HOME/.screen_scale`
+   else
+      continue
+   fi
+
+   normal_scale=8
+   touchscreen_scale=12
+   if [ "$old_screen_scale" != "$screen_scale" ]; then
+      old_screen_scale=$screen_scale
+      echo $screen_scale
+      case "$screen_scale" in
+         normal)
+           gsettings set com.ubuntu.user-interface scale-factor "{'eDP1': $normal_scale}"
+           ;;
+         touchscreen)
+           gsettings set com.ubuntu.user-interface scale-factor "{'eDP1': $touchscreen_scale}"
+           ;;
+      esac
+   fi
+sleep 0.5
+done
+

--- a/start_autorotate.sh
+++ b/start_autorotate.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+function zenityNotification
+{
+   echo "message:$1" | zenity --notification --listen &
+   mypid=$!
+   sleep 0.5
+   kill $mypid
+}
+
+
+# check if this script has already been run
+isModuleLoaded=`lsmod | grep hid_sensor_hub`
+if [[ -n $isModuleLoaded ]]; then
+   # check if autorotate.sh is already running, otherwise start it
+   isAutorotateRunning=`ps -A | grep autorotate.sh`
+   if [ -z $isAutorotateRunning ]; then
+      su root -c "autorotate.sh >/tmp/autorotate.log 2>&1 &"
+   fi
+   # this script has already been run, nothing to do here
+   exit 0
+fi
+
+# make screen accessible from root
+export DISPLAY=":0.0"
+xhost local:root
+
+# init vars
+tmpdir="/tmp/screen_management"
+mkdir $tmpdir
+echo "Autorotate" > $tmpdir/screen_orientation
+echo "normal" > $tmpdir/screen_scale
+chmod -R 777 $tmpdir
+
+# self-explanatory...
+zenity --question --ok-label="Proceed" --cancel-label="Reboot" --text="If this is a <b>cold boot</b>, please click on <b>'Reboot'</b> in order to allow screen autorotate to work\n\nif you have just rebooted the system, click on 'Proceed'" 
+
+case $? in
+   0) zenityNotification "Starting screen autorotate service...\nplease wait, it will take about 5 secs"
+   ;;
+   *) reboot
+esac   
+
+modprobe hid_sensor_hub
+sleep 2
+#sometimes the first time it doesn't work...
+modprobe hid_sensor_hub
+sleep 3
+
+autorotate.sh > /tmp/autorotate.log 2>&1 &
+
+exit 0
+

--- a/start_autorotate.sh
+++ b/start_autorotate.sh
@@ -8,19 +8,6 @@ function zenityNotification
    kill $mypid
 }
 
-
-# check if this script has already been run
-isModuleLoaded=`lsmod | grep hid_sensor_hub`
-if [[ -n $isModuleLoaded ]]; then
-   # check if autorotate.sh is already running, otherwise start it
-   isAutorotateRunning=`ps -A | grep autorotate.sh`
-   if [ -z $isAutorotateRunning ]; then
-      su root -c "autorotate.sh >/tmp/autorotate.log 2>&1 &"
-   fi
-   # this script has already been run, nothing to do here
-   exit 0
-fi
-
 # make screen accessible from root
 export DISPLAY=":0.0"
 xhost local:root
@@ -31,6 +18,19 @@ mkdir $tmpdir
 echo "Autorotate" > $tmpdir/screen_orientation
 echo "normal" > $tmpdir/screen_scale
 chmod -R 777 $tmpdir
+
+# check if this script has already been run
+isModuleLoaded=`lsmod | grep hid_sensor_hub`
+if [[ -n $isModuleLoaded ]]; then
+   # check if autorotate.sh is already running, otherwise start it
+   isAutorotateRunning=`ps -A | grep autorotate.sh`
+   if [ -z $isAutorotateRunning ]; then
+      autorotate.sh > /tmp/autorotate.log 2>&1 &
+   fi
+   # nothing more to do here
+   exit 0
+fi
+
 
 # self-explanatory...
 zenity --question --ok-label="Proceed" --cancel-label="Reboot" --text="If this is a <b>cold boot</b>, please click on <b>'Reboot'</b> in order to allow screen autorotate to work\n\nif you have just rebooted the system, click on 'Proceed'" 


### PR DESCRIPTION
I solved (well, found workarounds for) almost all problems.
Now the autorotate script runs as root, and the system does not freeze any more.
I have found that the hid_sensor_hub module frequently freezes when loaded, but only on cold boots, while it never freezes on reboots (but only if you load it at the end of the reboot process), so I wrote a new start_autorotate.sh script to handle all this

All the details in the README file

The next step will be to find a way to detect when the lid is turned 360°, in order to automatically set laptop or tablet mode (but I still have no idea on how to do that)
